### PR TITLE
Update on configure step

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Customize the attributes to suit site specific conventions and defaults.
 ### Actions
 - `:install`: extracts the file and creates a 'friendly' symbolic link to the extracted directory path
 - `:configure`: configure ahead of the install action
-- `:install_with_make`: extracts the archive to a path, runs `make`, and `make install`. It does _not_ run the configure step at this time
+- `:install_with_make`: extracts the archive to a path, runs `make`, and `make install`.
 - `:dump`: strips all directories from the archive and dumps the contained files into a specified path
 - `:cherry_pick`: extract a specified file from an archive and places in specified path
 - `:put`: extract the archive to a specified path, does not create any symbolic links


### PR DESCRIPTION
Perhaps I'm an idiot, but to me it looks like the configure step does indeed run as a part of `install_with_make`.

https://github.com/burtlo/ark/blob/63450b64d480515cd5960186fc434e2080657a69/providers/default.rb#L303

*Feel free to close immediately I'm wrong here (not too unlikely).*