### PR TITLE
Define custom matcher helper for notification testing, fixes #139

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,7 @@
 
 if defined?(ChefSpec)
+  ChefSpec.define_matcher :ark
+
   def install_ark(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:ark, :install, resource_name)
   end


### PR DESCRIPTION
Helps locating resource in context and it's used for notification
testing: https://github.com/sethvargo/chefspec#writing-custom-matchers

Thanks @monkey1016.