### PR TITLE
Get 7zip path from the windows registry.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,14 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 default['ark']['apache_mirror'] = 'http://apache.mirrors.tds.net'
 default['ark']['prefix_root'] = '/usr/local'
 default['ark']['prefix_bin'] = '/usr/local/bin'
 default['ark']['prefix_home'] = '/usr/local'
 default['ark']['tar'] = case node['platform_family']
                         when 'windows'
-                          "\"#{ENV['SYSTEMDRIVE']}\\7-zip\\7z.exe\""
+                          "\"#{::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+                            'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe', ::Win32::Registry::KEY_READ).read_s('Path')}\\7z.exe\""
                         when 'mac_os_x', 'freebsd'
                           '/usr/bin/tar'
                         when 'smartos'

--- a/spec/recipes/windows/default_spec.rb
+++ b/spec/recipes/windows/default_spec.rb
@@ -8,6 +8,25 @@ describe_recipe 'ark::default' do
   let(:expected_packages) do
     %w( libtool autoconf unzip rsync make gcc autogen xz-lzma-compat )
   end
+  
+  let(:fake_hkey_local_machine) do
+    fake_hkey_local_machine = double('fake_hkey_local_machine') 
+    seven_zip_win32_registry = double('seven_zip_registry')
+    allow(seven_zip_win32_registry).to receive(:read_s).with('Path').and_return('C:\\Program Files\\7-Zip')
+    allow(fake_hkey_local_machine).to receive(:open).with('SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe', ::Win32::Registry::KEY_READ).and_return(seven_zip_win32_registry)
+    fake_hkey_local_machine
+  end
+
+  before(:each) do
+    if not defined? ::Win32 
+      module Win32
+        class Registry
+        end
+      end
+    end
+    stub_const("::Win32::Registry::KEY_READ", double('win32_registry_key_read'))
+    stub_const("::Win32::Registry::HKEY_LOCAL_MACHINE", fake_hkey_local_machine)
+  end
 
   it 'does not installs packages' do
     expected_packages.each do |package|
@@ -21,7 +40,7 @@ describe_recipe 'ark::default' do
 
   context 'sets default attributes' do
     it 'tar binary' do
-      expect(default_cookbook_attribute('tar')).to eq %("\\7-zip\\7z.exe")
+      expect(default_cookbook_attribute('tar')).to eq %("C:\\Program Files\\7-Zip\\7z.exe")
     end
   end
 end

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -128,9 +128,25 @@ describe_resource 'ark' do
   describe 'install on windows' do
     let(:example_recipe) { 'ark_spec::install_windows' }
 
+    let(:fake_hkey_local_machine) do
+      fake_hkey_local_machine = double('fake_hkey_local_machine')
+      seven_zip_win32_registry = double('seven_zip_registry')
+      allow(seven_zip_win32_registry).to receive(:read_s).with('Path').and_return('C:\\Program Files\\7-Zip')
+      allow(fake_hkey_local_machine).to receive(:open).with('SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe', ::Win32::Registry::KEY_READ).and_return(seven_zip_win32_registry)
+      fake_hkey_local_machine
+    end
+
     before(:each) do
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with('SystemRoot').and_return('C:\\Windows')
+      if not defined? ::Win32
+        module Win32
+          class Registry
+          end
+        end
+      end
+      stub_const("::Win32::Registry::KEY_READ", double('win32_registry_key_read'))
+      stub_const("::Win32::Registry::HKEY_LOCAL_MACHINE", fake_hkey_local_machine)
     end
 
     def node_attributes


### PR DESCRIPTION
The current implementation assumes that the 7-zip is installed under %SYSTEMDRIVE%\\7-zip.

However, the latest sevenzip cookbook doesn't install 7-zip the above location.

This patch changes the logic to determine the 7-zip path same as the sevenzip cookbook.
See https://github.com/daptiv/seven_zip/blob/master/providers/archive.rb.