### PR TITLE
Use fullpath for xcopy and icacls.

### DIFF
--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -37,7 +37,7 @@ module Ark
         currdir += "\\%#{count}"
       end
 
-      cmd += "xcopy \"#{currdir}\" \"#{resource.home_dir}\" /s /e"
+      cmd += "#{ENV.fetch('SystemRoot')}\\System32\\xcopy \"#{currdir}\" \"#{resource.home_dir}\" /s /e"
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/libraries/windows_owner.rb
+++ b/libraries/windows_owner.rb
@@ -7,7 +7,7 @@ module Ark
     attr_reader :resource
 
     def command
-      "icacls \"#{resource.path}\\*\" /setowner \"#{resource.owner}\""
+      "#{ENV.fetch('SystemRoot')}\\System32\\icacls \"#{resource.path}\\*\" /setowner \"#{resource.owner}\""
     end
   end
 end

--- a/spec/libraries/default_spec.rb
+++ b/spec/libraries/default_spec.rb
@@ -4,6 +4,8 @@ require './libraries/default'
 describe_helpers Ark::ProviderHelpers do
   before(:each) do
     allow_any_instance_of(Ark::ResourceDefaults).to receive(:file_cache_path).and_return('/var/chef/cache')
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('SystemRoot').and_return('C:\\Windows')
   end
 
   describe '#owner_command' do
@@ -12,7 +14,7 @@ describe_helpers Ark::ProviderHelpers do
         with_node_attributes(platform_family: 'windows')
         with_resource_properties(owner: 'Bobo', path: 'C:\\temp')
 
-        expect(owner_command).to eq('icacls "C:\\temp\\*" /setowner "Bobo"')
+        expect(owner_command).to eq('C:\\Windows\\System32\\icacls "C:\\temp\\*" /setowner "Bobo"')
       end
     end
 

--- a/spec/libraries/sevenzip_command_builder_spec.rb
+++ b/spec/libraries/sevenzip_command_builder_spec.rb
@@ -15,12 +15,14 @@ describe Ark::SevenZipCommandBuilder do
 
   before(:each) do
     allow(subject).to receive(:sevenzip_binary) { '"C:\\Program Files\\7-zip\\7z.exe"' }
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('SystemRoot').and_return('c:\\Windows')
   end
 
   describe '#unpack' do
     it 'generates the correct command' do
       allow(subject).to receive(:make_temp_directory) { 'temp_directory' }
-      expected_command = "\"C:\\Program Files\\7-zip\\7z.exe\" e \"release_file\" -so | \"C:\\Program Files\\7-zip\\7z.exe\" x -aoa -si -ttar -o\"temp_directory\" -uy && for /f %1 in ('dir /ad /b \"temp_directory\"') do xcopy \"temp_directory\\%1\" \"home_dir\" /s /e"
+      expected_command = "\"C:\\Program Files\\7-zip\\7z.exe\" e \"release_file\" -so | \"C:\\Program Files\\7-zip\\7z.exe\" x -aoa -si -ttar -o\"temp_directory\" -uy && for /f %1 in ('dir /ad /b \"temp_directory\"') do c:\\Windows\\System32\\xcopy \"temp_directory\\%1\" \"home_dir\" /s /e"
       expect(subject.unpack).to eq(expected_command)
     end
   end

--- a/spec/libraries/windows_owner_spec.rb
+++ b/spec/libraries/windows_owner_spec.rb
@@ -6,7 +6,12 @@ describe Ark::WindowsOwner do
 
   let(:resource) { double(path: 'c:\\resource with spaces\\path', owner: 'the new owner') }
 
+  before(:each) do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('SystemRoot').and_return('C:\\Windows')
+  end
+
   it 'generates the correct command for windows file ownership' do
-    expect(subject.command).to eq('icacls "c:\\resource with spaces\\path\\*" /setowner "the new owner"')
+    expect(subject.command).to eq('C:\\Windows\\System32\\icacls "c:\\resource with spaces\\path\\*" /setowner "the new owner"')
   end
 end

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -128,6 +128,11 @@ describe_resource 'ark' do
   describe 'install on windows' do
     let(:example_recipe) { 'ark_spec::install_windows' }
 
+    before(:each) do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('SystemRoot').and_return('C:\\Windows')
+    end
+
     def node_attributes
       { platform: 'windows', version: '2008R2' }
     end


### PR DESCRIPTION
The current implementation doesn't specify full path of xcopy and icacls.

If the environment attributes is not specified or the PATH environment variable in the environment hash doesn't contain %SystemRoot%\System32, the invocations of the commands will fail.

