### PR TITLE
Get 7zip path from the windows registry.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,8 @@ default['ark']['prefix_bin'] = '/usr/local/bin'
 default['ark']['prefix_home'] = '/usr/local'
 default['ark']['tar'] = case node['platform_family']
                         when 'windows'
-                          "\"#{ENV['SYSTEMDRIVE']}\\7-zip\\7z.exe\""
+                          "\"#{::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+                            'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe', ::Win32::Registry::KEY_READ).read_s('Path')}\\7z.exe\""
                         when 'mac_os_x', 'freebsd'
                           '/usr/bin/tar'
                         when 'smartos'

--- a/spec/recipes/windows/default_spec.rb
+++ b/spec/recipes/windows/default_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe_recipe 'ark::default' do
+  include_context 'seven zip installed'
+
   def node_attributes
     { platform: 'windows', version: '2012R2' }
   end
@@ -21,7 +23,7 @@ describe_recipe 'ark::default' do
 
   context 'sets default attributes' do
     it 'tar binary' do
-      expect(default_cookbook_attribute('tar')).to eq %("\\7-zip\\7z.exe")
+      expect(default_cookbook_attribute('tar')).to eq %("C:\\Program Files\\7-Zip\\7z.exe")
     end
   end
 end

--- a/spec/resources/default_spec.rb
+++ b/spec/resources/default_spec.rb
@@ -126,6 +126,8 @@ describe_resource 'ark' do
   end
 
   describe 'install on windows' do
+    include_context('seven zip installed')
+
     let(:example_recipe) { 'ark_spec::install_windows' }
 
     before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,3 +110,24 @@ Please specify the name of the test recipe that executes your recipe:
     cookbook_recipe_names.last
   end
 end
+
+shared_context 'seven zip installed' do
+  let(:fake_hkey_local_machine) do
+    fake_hkey_local_machine = double('fake_hkey_local_machine')
+    seven_zip_win32_registry = double('seven_zip_registry')
+    allow(seven_zip_win32_registry).to receive(:read_s).with('Path').and_return('C:\\Program Files\\7-Zip')
+    allow(fake_hkey_local_machine).to receive(:open).with('SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe', ::Win32::Registry::KEY_READ).and_return(seven_zip_win32_registry)
+    fake_hkey_local_machine
+  end
+
+  before(:each) do
+    unless defined? ::Win32
+      module Win32
+        class Registry
+        end
+      end
+    end
+    stub_const('::Win32::Registry::KEY_READ', double('win32_registry_key_read')) unless defined? ::Win32::Registry::KEY_READ
+    stub_const('::Win32::Registry::HKEY_LOCAL_MACHINE', fake_hkey_local_machine)
+  end
+end


### PR DESCRIPTION
This patch is modified version of #151.

The current implementation assumes that the 7-zip is installed under %SYSTEMDRIVE%\\7-zip.

However, the latest sevenzip cookbook doesn't install 7-zip the above location.

This patch changes the logic to determine the 7-zip path same as the sevenzip cookbook.
See https://github.com/daptiv/seven_zip/blob/master/providers/archive.rb.