### PR TITLE
Sniff .7z file extensions

### DIFF
--- a/libraries/resource_defaults.rb
+++ b/libraries/resource_defaults.rb
@@ -62,13 +62,13 @@ module Ark
 
     def generate_extension_from_url(url)
       # purge any trailing redirect
-      url =~ %r{^https?:\/\/.*(.bin|bz2|gz|jar|tbz|tgz|txz|war|xz|zip)(\/.*\/)}
+      url =~ %r{^https?:\/\/.*(.bin|bz2|gz|jar|tbz|tgz|txz|war|xz|zip|7z)(\/.*\/)}
       url.gsub!(Regexp.last_match(2), '') unless Regexp.last_match(2).nil?
-      # remove tailing query string
+      # remove trailing query string
       release_basename = ::File.basename(url.gsub(/\?.*\z/, '')).gsub(/-bin\b/, '')
       # (\?.*)? accounts for a trailing querystring
       Chef::Log.debug("DEBUG: release_basename is #{release_basename}")
-      release_basename =~ /^(.+?)\.(jar|tar\.bz2|tar\.gz|tar\.xz|tbz|tgz|txz|war|zip|tar)(\?.*)?/
+      release_basename =~ /^(.+?)\.(jar|tar\.bz2|tar\.gz|tar\.xz|tbz|tgz|txz|war|zip|tar|7z)(\?.*)?/
       Chef::Log.debug("DEBUG: file_extension is #{Regexp.last_match(2)}")
       Regexp.last_match(2)
     end

--- a/spec/libraries/resource_defaults_spec.rb
+++ b/spec/libraries/resource_defaults_spec.rb
@@ -32,6 +32,12 @@ describe Ark::ResourceDefaults do
         expect(defaults.extension).to eq 'tar'
       end
 
+      it 'creates an extension for 7z files' do
+        resource = double(extension: nil, url: 'https://sourceforge.net/projects/boost/files/boost/1.62.0/boost_1_62_0.7z')
+        defaults = described_class.new(resource)
+        expect(defaults.extension).to eq '7z'
+      end
+
       context 'when the archive format is not supported' do
         it 'it returns a nil extension' do
           resource = double(extension: nil, url: 'http://localhost/file.stuffit')


### PR DESCRIPTION
### Description

Detects extension for files ending in .7z

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

