### PR TITLE
Fix #164 - When using 7zip to extract with strip_components >= 1 (default is 1) extracts to home_dir, not path

### DIFF
--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -40,7 +40,7 @@ module Ark
         currdir += "\\%#{count}"
       end
 
-      cmd += "#{ENV.fetch('SystemRoot')}\\System32\\xcopy \"#{currdir}\" \"#{resource.home_dir}\" /s /e"
+      cmd += "#{ENV.fetch('SystemRoot')}\\System32\\xcopy \"#{currdir}\" \"#{resource.path}\" /s /e"
     end
 
     def sevenzip_binary
@@ -66,7 +66,7 @@ module Ark
       if resource.extension =~ /tar.gz|tgz|tar.bz2|tbz|tar.xz|txz/
         " -so | #{sevenzip_binary} x -aoa -si -ttar"
       else
-        ''
+        ' -aoa' # force overwrite, Fixes #164
       end
     end
 

--- a/spec/libraries/default_spec.rb
+++ b/spec/libraries/default_spec.rb
@@ -134,7 +134,7 @@ describe_helpers Ark::ProviderHelpers do
           run_context: double(node: { 'ark' => { 'tar' => 'sevenzip_command' } })
         )
 
-        expect(cherry_pick_command).to eq('C:\\Program Files\\7-Zip7z.exe e "/resource/release_file" -o"/resource/path" -uy -r /resource/creates')
+        expect(cherry_pick_command).to eq('C:\\Program Files\\7-Zip7z.exe e "/resource/release_file" -aoa -o"/resource/path" -uy -r /resource/creates')
       end
     end
 

--- a/spec/libraries/sevenzip_command_builder_spec.rb
+++ b/spec/libraries/sevenzip_command_builder_spec.rb
@@ -22,7 +22,7 @@ describe Ark::SevenZipCommandBuilder do
   describe '#unpack' do
     it 'generates the correct command' do
       allow(subject).to receive(:make_temp_directory) { 'temp_directory' }
-      expected_command = "\"C:\\Program Files\\7-zip\\7z.exe\" e \"release_file\" -so | \"C:\\Program Files\\7-zip\\7z.exe\" x -aoa -si -ttar -o\"temp_directory\" -uy && for /f %1 in ('dir /ad /b \"temp_directory\"') do c:\\Windows\\System32\\xcopy \"temp_directory\\%1\" \"home_dir\" /s /e"
+      expected_command = "\"C:\\Program Files\\7-zip\\7z.exe\" e \"release_file\" -so | \"C:\\Program Files\\7-zip\\7z.exe\" x -aoa -si -ttar -o\"temp_directory\" -uy && for /f %1 in ('dir /ad /b \"temp_directory\"') do c:\\Windows\\System32\\xcopy \"temp_directory\\%1\" \"path\" /s /e"
       expect(subject.unpack).to eq(expected_command)
     end
   end


### PR DESCRIPTION
### Description
When extracting a 7zip file with strip_components >= 1, now correctly extracts to resource.path (which ultimately is win_install_dir on Windows).
Also fixes to force overwrite without prompting on extracting non-tar files (i.e. *.7z files).

### Issues Resolved
- #164 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>