### PR TITLE
Always quote the sevenzip_binary path and path to xcopy.

### DIFF
--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -40,11 +40,11 @@ module Ark
         currdir += "\\%#{count}"
       end
 
-      cmd += "#{ENV.fetch('SystemRoot')}\\System32\\xcopy \"#{currdir}\" \"#{resource.home_dir}\" /s /e"
+      cmd += "\"#{ENV.fetch('SystemRoot')}\\System32\\xcopy\" \"#{currdir}\" \"#{resource.home_dir}\" /s /e"
     end
 
     def sevenzip_binary
-      @tar_binary ||= (node['ark']['sevenzip_binary'] || sevenzip_path_from_registry)
+      @tar_binary ||= "\"#{(node['ark']['sevenzip_binary'] || sevenzip_path_from_registry)}\""
     end
 
     def sevenzip_path_from_registry


### PR DESCRIPTION
### Description

If the resolved path to 7-zip's binary using registry search is used, the path typically is under "C\Program Files\", which has a space in the path name, but the binary/exe path is not quoted in the full command to execute. This results in failed execution under typical usage, and requires an explicit setting of node['ark']['sevenzip_binary'] to a quoted path.

It's counter-intuitive to have to add wrapping quotes to that attribute anyhow, we'd expect to be able to just use a normal string value, not extra wrapping quotes too.

```
==> default: [2016-11-17T19:59:05+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: ark[cmake] (jenkins-win10-slave::default line 40) had an error: Mixlib::ShellOut::ShellCommandFailed: execute[unpack C:/chef/cache/cmake-3.7.0-rc3.zip] (C:/chef/cache/cookbooks/ark/providers/default.rb line 51) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
==> default: ---- Begin output of c:\Program Files\7-Zip\7z.exe e "C:/chef/cache/cmake-3.7.0-rc3.zip" -aoa -o"C:/Users/vagrant/AppData/Local/Temp/d20161117-3740-10vxzdl" -uy && for /f %1 in ('dir /ad /b "C:\Users\vagrant\AppData\Local\Temp\d20161117-3740-10vxzdl"') do C:\Windows\System32\xcopy "C:\Users\vagrant\AppData\Local\Temp\d20161117-3740-10vxzdl\%1" "C:\Program Files (x86)\cmake" /s /e ----
==> default: STDOUT: 
==> default: STDERR: 'c:\Program' is not recognized as an internal or external command,
==> default: 
==> default: operable program or batch file.
==> default: ---- End output of c:\Program Files\7-Zip\7z.exe e "C:/chef/cache/cmake-3.7.0-rc3.zip" -aoa -o"C:/Users/vagrant/AppData/Local/Temp/d20161117-3740-10vxzdl" -uy && for /f %1 in ('dir /ad /b "C:\Users\vagrant\AppData\Local\Temp\d20161117-3740-10vxzdl"') do C:\Windows\System32\xcopy "C:\Users\vagrant\AppData\Local\Temp\d20161117-3740-10vxzdl\%1" "C:\Program Files (x86)\cmake" /s /e ----
==> default: Ran c:\Program Files\7-Zip\7z.exe e "C:/chef/cache/cmake-3.7.0-rc3.zip" -aoa -o"C:/Users/vagrant/AppData/Local/Temp/d20161117-3740-10vxzdl" -uy && for /f %1 in ('dir /ad /b "C:\Users\vagrant\AppData\Local\Temp\d20161117-3740-10vxzdl"') do C:\Windows\System32\xcopy "C:\Users\vagrant\AppData\Local\Temp\d20161117-3740-10vxzdl\%1" "C:\Program Files (x86)\cmake" /s /e returned 1
```

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Christopher Williams <chris.a.williams@gmail.com>
