### PR TITLE
Fix #138 - Use x to extract with 7-zip, not e. Use e only for dump, which strips directories.

### DIFF
--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -9,7 +9,7 @@ module Ark
     end
 
     def cherry_pick
-      "#{sevenzip_command_builder(resource.path, 'e')} -r #{resource.creates}"
+      "#{sevenzip_command_builder(resource.path, 'x')} -r #{resource.creates}"
     end
 
     def initialize(resource)
@@ -30,7 +30,7 @@ module Ark
       end
 
       tmpdir = make_temp_directory
-      cmd = sevenzip_command_builder(tmpdir, 'e')
+      cmd = sevenzip_command_builder(tmpdir, 'x')
 
       cmd += ' && '
       currdir = tmpdir.tr('/', '\\')

--- a/spec/libraries/sevenzip_command_builder_spec.rb
+++ b/spec/libraries/sevenzip_command_builder_spec.rb
@@ -22,7 +22,7 @@ describe Ark::SevenZipCommandBuilder do
   describe '#unpack' do
     it 'generates the correct command' do
       allow(subject).to receive(:make_temp_directory) { 'temp_directory' }
-      expected_command = "\"C:\\Program Files\\7-zip\\7z.exe\" e \"release_file\" -so | \"C:\\Program Files\\7-zip\\7z.exe\" x -aoa -si -ttar -o\"temp_directory\" -uy && for /f %1 in ('dir /ad /b \"temp_directory\"') do c:\\Windows\\System32\\xcopy \"temp_directory\\%1\" \"home_dir\" /s /e"
+      expected_command = "\"C:\\Program Files\\7-zip\\7z.exe\" x \"release_file\" -so | \"C:\\Program Files\\7-zip\\7z.exe\" x -aoa -si -ttar -o\"temp_directory\" -uy && for /f %1 in ('dir /ad /b \"temp_directory\"') do c:\\Windows\\System32\\xcopy \"temp_directory\\%1\" \"home_dir\" /s /e"
       expect(subject.unpack).to eq(expected_command)
     end
   end
@@ -36,7 +36,7 @@ describe Ark::SevenZipCommandBuilder do
 
   describe '#cherry_pick' do
     it 'generates the correct command' do
-      expected_command = '"C:\\Program Files\\7-zip\\7z.exe" e "release_file" -so | "C:\\Program Files\\7-zip\\7z.exe" x -aoa -si -ttar -o"path" -uy -r creates'
+      expected_command = '"C:\\Program Files\\7-zip\\7z.exe" x "release_file" -so | "C:\\Program Files\\7-zip\\7z.exe" x -aoa -si -ttar -o"path" -uy -r creates'
       expect(subject.cherry_pick).to eq(expected_command)
     end
   end


### PR DESCRIPTION
### Description

Changes from using the 'e' command to 'x' for 7-zip on all actions other than dump. 'e' extracts and strips directories. 'x' extracts with full paths. See https://sevenzip.osdn.jp/chm/cmdline/commands/index.htm

⚠️ I'm not sure if we actually **need** to use 'e' for the special case of tar files. That particular use case involves using two piped 7zip commands, and I don't know if one of those two needs to use 'e' for some reason.

### Issues Resolved
- #138

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Christopher Williams <chris.a.williams@gmail.com>