### PR TITLE
Fix #169 - Files with very long paths fail to extract on Windows

### DIFF
--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -40,7 +40,7 @@ module Ark
         currdir += "\\%#{count}"
       end
 
-      cmd += "#{ENV.fetch('SystemRoot')}\\System32\\xcopy \"#{currdir}\" \"#{resource.home_dir}\" /s /e"
+      cmd += "(#{ENV.fetch('SystemRoot')}\\System32\\robocopy \"#{currdir}\" \"#{resource.home_dir}\" /s /e) ^& IF %ERRORLEVEL% LEQ 3 cmd /c exit 0"
     end
 
     def sevenzip_binary

--- a/libraries/sevenzip_command_builder.rb
+++ b/libraries/sevenzip_command_builder.rb
@@ -29,11 +29,11 @@ module Ark
         return sevenzip_command_builder(resource.path, 'x')
       end
 
-      tmpdir = make_temp_directory
+      tmpdir = make_temp_directory.tr('/', '\\')
       cmd = sevenzip_command_builder(tmpdir, 'e')
 
       cmd += ' && '
-      currdir = tmpdir.tr('/', '\\')
+      currdir = tmpdir
 
       1.upto(resource.strip_components).each do |count|
         cmd += "for /f %#{count} in ('dir /ad /b \"#{currdir}\"') do "


### PR DESCRIPTION
### Description

Uses robocopy instead of copy to be able to deal with paths over 260 characters long. Smooths out robocopy's exit codes of 0-3 to become 0 (0-3 indicate successful exits with varying meanings, but typically you'd see an exit code of 1 for a successful fresh copy) - so that chef doesn't think the copy failed under those success scenarios.

This does mean that this will not work on older Windows versions unless the user installs robocopy separately. According to https://en.wikipedia.org/wiki/Robocopy#Versions and https://technet.microsoft.com/en-us/library/cc733145(v=ws.11).aspx it's been bundled in Windows Server 2008 &2012; Windows Vista, 7, 8, 8.1, and 10. Given that range, I think it's still a relatively good choice.

### Issues Resolved

- #169 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>