### PR TITLE
Fix #168 Default owner of 'root' fails on Windows

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -49,6 +49,7 @@ module Ark
       new_resource.prefix_root = defaults.prefix_root
       new_resource.home_dir = defaults.home_dir
       new_resource.version = defaults.version
+      new_resource.owner = defaults.owner
 
       # TODO: what happens when the path is already set --
       #   with the current logic we overwrite it

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -41,7 +41,7 @@ attr_accessor :extension,
   :release_file,
   :version
 
-attribute :owner, kind_of: String, default: 'root'
+attribute :owner, kind_of: String, default: nil
 attribute :group, kind_of: [String, Fixnum], default: 0
 attribute :url, kind_of: String, required: true
 attribute :path, kind_of: String, default: nil


### PR DESCRIPTION
### Description
Changes default of owner on resource from 'root' to nil. Then uses lazy init to set default owner if the value is still nil. On non-windows, sets 'root'. On Windows, uses WMI query to grab local admin account (typically 'Administrator'). The code for grabbing the windows admin user was copied from https://github.com/chef-cookbooks/chef-client/blob/master/libraries/helpers.rb#L37

Ultimately the WMI query code in that helper looks very similar to the one in the windows cookbook here: https://github.com/chef-cookbooks/windows/blob/master/libraries/wmi_helper.rb#L22

Perhaps both this and the chef-client cookbook can just re-use it?


### Issues Resolved
- #168

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
