### PR TITLE
Hardcoding group as root causes error on Mac

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -80,8 +80,8 @@ action :install do
     template "/etc/profile.d/#{new_resource.name}.sh" do
       cookbook 'ark'
       source 'add_to_path.sh.erb'
-      owner 'root'
-      group 'root'
+      owner 0
+      group 0
       mode '0755'
       cookbook 'ark'
       variables(directory: "#{new_resource.path}/bin")


### PR DESCRIPTION
Mac throws an error due to there being no root group, should be wheel
in this case. Substituted 0 into the group field so that group will be
‘root’ on Ubuntu, and ‘wheel’ on Mac. Owner attribute also changed for
consistency.