### PR TITLE
On Mac OSX, root group should be 'wheel'.

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -62,7 +62,7 @@ action :install do
     action :nothing
   end
 
-  # usually on windows there is no central directory with executables where the applciations are linked
+  # usually on windows there is no central directory with executables where the applications are linked
   unless node['platform_family'] == 'windows'
     # symlink binaries
     new_resource.has_binaries.each do |bin|
@@ -81,7 +81,7 @@ action :install do
       cookbook 'ark'
       source 'add_to_path.sh.erb'
       owner 'root'
-      group 'root'
+      group platform?('mac_os_x') ? 'wheel' : 'root'
       mode '0755'
       cookbook 'ark'
       variables(directory: "#{new_resource.path}/bin")

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -81,7 +81,7 @@ action :install do
       cookbook 'ark'
       source 'add_to_path.sh.erb'
       owner 'root'
-      group platform?('mac_os_x') ? 'wheel' : 'root'
+      group node['root_group']
       mode '0755'
       cookbook 'ark'
       variables(directory: "#{new_resource.path}/bin")


### PR DESCRIPTION
### Description

Uses 'root' for group owner on /etc/profile.d script for non-Windows/OSX platforms, uses 'wheel' on OSX.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Christopher Williams <chris.a.williams@gmail.com>