### PR TITLE
Support append_env_path property on Windows.

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -83,8 +83,16 @@ action :install do
     action :nothing
   end
 
-  # usually on windows there is no central directory with executables where the applications are linked
-  unless node['platform_family'] == 'windows'
+  if node['platform_family'] == 'windows'
+    # usually on windows there is no central directory with executables where the applications are linked
+    # so ignore has_binaries for now
+
+    # Add to PATH permanently on Windows if append_env_path
+    windows_path "#{new_resource.path}/bin" do
+      action :add
+      only_if { new_resource.append_env_path }
+    end
+  else
     # symlink binaries
     new_resource.has_binaries.each do |bin|
       link ::File.join(new_resource.prefix_bin, ::File.basename(bin)) do


### PR DESCRIPTION
### Description

Supports usage of the append_env_path property for Windows.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Christopher Williams <chris.a.williams@gmail.com>