### PR TITLE
Fix #181 by adding accessor for :owner

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,6 +35,7 @@ default_action :install
 
 attr_accessor :extension,
   :home_dir,
+  :owner,
   :path,
   :prefix_bin,
   :prefix_root,


### PR DESCRIPTION
Signed-off-by: Derek Wood <derek@cask.co>

### Description

[This line](https://github.com/chef-cookbooks/ark/blob/master/libraries/default.rb#L52), introduced in #171, tries to set the ``:owner`` attribute but no accessor exists.  This just adds the missing accessor.

### Issues Resolved

#181

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
