### PR TITLE
Update zlib after old version's URI no longer valid.

### DIFF
--- a/spec/fixtures/cookbooks/ark_spec/recipes/default.rb
+++ b/spec/fixtures/cookbooks/ark_spec/recipes/default.rb
@@ -139,7 +139,7 @@ ark 'test_notification' do
 end
 
 ark 'test_autogen' do
-  url 'http://zlib.net/zlib-1.2.8.tar.gz'
+  url 'http://zlib.net/zlib-1.2.11.tar.gz'
   extension 'tar.gz'
   action :configure
 end


### PR DESCRIPTION
### Description

Allow tests to pass - zlib-1.2.8 is no longer accessible using the URI in the default ark fixtures. Updated to 1.2.11.

### Issues Resolved

None reported.

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [NA ] New functionality includes testing.
- [ NA] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
